### PR TITLE
Fixed removeCallback in CallbackProxy

### DIFF
--- a/Android/Source/src/im/delight/android/ddp/CallbackProxy.java
+++ b/Android/Source/src/im/delight/android/ddp/CallbackProxy.java
@@ -34,7 +34,7 @@ public class CallbackProxy implements MeteorCallback {
 	}
 
 	public void removeCallback(final MeteorCallback callback) {
-		mCallbacks.add(callback);
+		mCallbacks.remove(callback);
 	}
 
 	public void removeCallbacks() {


### PR DESCRIPTION
The CallbackProxy.removeCallback method was adding the listener to the callbacks list instead of removing it.