### PR TITLE
Nv websocket client - subscription stopped callback and select the looper for callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Connect your native Android apps, written in Java, to apps built with the [Meteo
 
      ```gradle
      dependencies {
-         compile 'com.github.delight-im:Android-DDP:v3.1.2'
+         compile 'com.github.delight-im:Android-DDP:v3.2.0'
      }
      ```
 
@@ -376,6 +376,18 @@ Query query = mMeteor.getDatabase().getCollection(collectionName).whereNull(fiel
 ```java
 // String fieldName = "modifiedAt";
 Query query = mMeteor.getDatabase().getCollection(collectionName).whereNotNull(fieldName);
+```
+
+```java
+// String fieldName = "age";
+// Integer[] fieldValues = new Integer[] { 60, 70, 80 };
+Query query = mMeteor.getDatabase().getCollection(collectionName).whereIn(fieldName, fieldValues);
+```
+
+```java
+// String fieldName = "languageCode";
+// String[] fieldValues = new String[] { "zh", "es", "en", "hi", "ar" };
+Query query = mMeteor.getDatabase().getCollection(collectionName).whereNotIn(fieldName, fieldValues);
 ```
 
 Any query can be executed by a `find` or `findOne` call. The step of first creating the `Query` instance can be skipped if you chain the calls to execute the query immediately.

--- a/Source/build.gradle
+++ b/Source/build.gradle
@@ -4,8 +4,8 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:1.5.0'
-		classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 	}
 }
 

--- a/Source/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Sat Jan 14 22:25:00 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/Source/library/src/main/java/im/delight/android/ddp/CallbackProxy.java
+++ b/Source/library/src/main/java/im/delight/android/ddp/CallbackProxy.java
@@ -18,6 +18,7 @@ package im.delight.android.ddp;
 
 import android.os.Handler;
 import android.os.Looper;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -25,9 +26,15 @@ import java.util.List;
 public class CallbackProxy implements MeteorCallback {
 
 	private final List<MeteorCallback> mCallbacks = new LinkedList<MeteorCallback>();
-	private final Handler mUiHandler = new Handler(Looper.getMainLooper());
+	private final Handler mUiHandler/* = new Handler(Looper.getMainLooper())*/;
 
-	public CallbackProxy() { }
+	public CallbackProxy() {
+		mUiHandler = new Handler(Looper.getMainLooper());
+	}
+
+	public CallbackProxy(Looper i_looperForCallbacks) {
+		mUiHandler = new Handler(i_looperForCallbacks);
+	}
 
 	public void addCallback(final MeteorCallback callback) {
 		mCallbacks.add(callback);
@@ -134,6 +141,26 @@ public class CallbackProxy implements MeteorCallback {
 					public void run() {
 						// run the proxied method with the same parameters
 						callback.onDataRemoved(collectionName, documentID);
+					}
+
+				});
+			}
+		}
+	}
+	
+	@Override
+	public void onNoSub(final String subscriptionId) {
+		// iterate over all the registered callbacks
+		for (final MeteorCallback callback : mCallbacks) {
+			// if the callback exists
+			if (callback != null) {
+				// execute the callback on the main thread
+				mUiHandler.post(new Runnable() {
+
+					@Override
+					public void run() {
+						// run the proxied method with the same parameters
+						callback.onNoSub(subscriptionId);
 					}
 
 				});

--- a/Source/library/src/main/java/im/delight/android/ddp/DdpCallback.java
+++ b/Source/library/src/main/java/im/delight/android/ddp/DdpCallback.java
@@ -45,5 +45,13 @@ public interface DdpCallback {
 	 * @param documentID the ID of the document that is being removed
 	 */
 	void onDataRemoved(String collectionName, String documentID);
-
+	
+	/**
+	 * Callback that is executed whenever a subscription stopped and there are no listeners waiting for it.
+	 * This can happen when the server decides to stop the subscription or when
+	 * subscribing or unsubscribing without a listener.
+	 *  
+	 * @param subscriptionId The subscription ID returned by subscribe.
+	 */
+	void onNoSub(String subscriptionId);
 }

--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -1,0 +1,11 @@
+// MiaTua added file for adding the needed options to the android build of cordova.
+// This file will be copied to the cordova build for android.
+// See https://www.thepolyglotdeveloper.com/2015/06/extending-the-gradle-build-file-in-apache-cordova-5-0/
+android {
+	packagingOptions {
+		exclude 'META-INF/LICENSE'
+		exclude 'META-INF/NOTICE'
+		exclude 'META-INF/ASL2.0'
+	}
+}
+


### PR DESCRIPTION
Add callback that is executed whenever a subscription stopped and there are no listeners waiting for it (i.e. after subscription is ready).

Added option to select the looper that all callbacks will be fired on. This already makes sure that callbacks are fired on the user thread.

Exposed getLoginToken() so that other access methods (REST calls) can use the same login information.