### PR TITLE
Expose session ID

### DIFF
--- a/Source/library/src/main/java/im/delight/android/ddp/Meteor.java
+++ b/Source/library/src/main/java/im/delight/android/ddp/Meteor.java
@@ -1269,5 +1269,14 @@ public class Meteor {
 			return null;
 		}
 	}
+	
+	/**
+	 * Returns the session ID for the connection
+	 *
+	 * @return the session ID or 'null'
+	 */
+	public String getSessionID() {
+		return mSessionID;
+	}
 
 }


### PR DESCRIPTION
Session ID is still useful to the client in special circumstances and should be accessible.